### PR TITLE
Hello! I've just added environment profiles for Spring Boot and React.

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,19 @@
+# Auth Service
+
+## Environment Configuration
+
+The Spring Boot application utilizes Maven profiles to manage environment-specific configurations, particularly for CORS settings.
+
+### Profiles
+- `local`: For local development. Sets CORS for `http://127.0.0.1:5173` and `http://localhost:5173`.
+- `dev`: For the development environment.
+- `uat`: For the UAT environment.
+- `prod`: For the production environment.
+
+Each profile activates a corresponding `application-<profile>.properties` file. The `dev`, `uat`, and `prod` profiles have placeholder CORS origins that need to be configured with the actual frontend URLs for those environments.
+
+### Running Locally
+- **Using IDE:** Select the `local` Maven profile when running the application.
+- **Command Line:** Navigate to the `auth-service` directory and run `mvn spring-boot:run -Plocal`.
+
+CORS is configured in `mcc.survey.creator.config.WebConfig` based on properties loaded from the active profile.

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
+		<spring.profiles.active>local</spring.profiles.active>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -86,5 +87,44 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>local</id>
+			<properties>
+				<spring.profiles.active>local</spring.profiles.active>
+			</properties>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>dev</id>
+			<properties>
+				<spring.profiles.active>dev</spring.profiles.active>
+			</properties>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>uat</id>
+			<properties>
+				<spring.profiles.active>uat</spring.profiles.active>
+			</properties>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>prod</id>
+			<properties>
+				<spring.profiles.active>prod</spring.profiles.active>
+			</properties>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+		</profile>
+	</profiles>
 
 </project>

--- a/auth-service/src/main/java/mcc/survey/creator/config/WebConfig.java
+++ b/auth-service/src/main/java/mcc/survey/creator/config/WebConfig.java
@@ -1,0 +1,28 @@
+package mcc.survey.creator.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Value("${cors.allowed-origins}")
+    private String[] allowedOrigins;
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedOrigins)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/auth-service/src/main/resources/application-dev.properties
+++ b/auth-service/src/main/resources/application-dev.properties
@@ -1,0 +1,3 @@
+server.port=8080
+# Define allowed origins for the dev environment (replace with actual dev frontend URL)
+cors.allowed-origins=http://dev-survey.example.com

--- a/auth-service/src/main/resources/application-local.properties
+++ b/auth-service/src/main/resources/application-local.properties
@@ -1,0 +1,3 @@
+server.port=8080
+# Define allowed origins for local development (React default port)
+cors.allowed-origins=http://127.0.0.1:5173,http://localhost:5173

--- a/auth-service/src/main/resources/application-local.properties
+++ b/auth-service/src/main/resources/application-local.properties
@@ -1,3 +1,15 @@
 server.port=8080
 # Define allowed origins for local development (React default port)
 cors.allowed-origins=http://127.0.0.1:5173,http://localhost:5173
+
+spring.application.name=auth-service
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+
+app.jwt.secret=your-super-secret-key-which-should-be-long-and-complex-and-at-least-64-characters-long-for-HS512
+app.jwt.expiration-ms=3600000
+app.jwt.refresh-token-expiration-ms=86400000

--- a/auth-service/src/main/resources/application-prod.properties
+++ b/auth-service/src/main/resources/application-prod.properties
@@ -1,0 +1,3 @@
+server.port=8080
+# Define allowed origins for the production environment (replace with actual prod frontend URL)
+cors.allowed-origins=http://survey.example.com

--- a/auth-service/src/main/resources/application-uat.properties
+++ b/auth-service/src/main/resources/application-uat.properties
@@ -1,0 +1,3 @@
+server.port=8080
+# Define allowed origins for the UAT environment (replace with actual UAT frontend URL)
+cors.allowed-origins=http://uat-survey.example.com

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,11 +1,4 @@
-spring.application.name=auth-service
-spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.profiles.active=@spring.profiles.active@
 
-app.jwt.secret=your-super-secret-key-which-should-be-long-and-complex-and-at-least-64-characters-long-for-HS512
-app.jwt.expiration-ms=3600000
-app.jwt.refresh-token-expiration-ms=86400000
+# Default CORS settings (will be overridden by profiles)
+cors.allowed-origins=

--- a/survey-creator-portal/.env.development
+++ b/survey-creator-portal/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://dev-auth-service.example.com/api/auth

--- a/survey-creator-portal/.env.production
+++ b/survey-creator-portal/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://prod-auth-service.example.com/api/auth

--- a/survey-creator-portal/.env.uat
+++ b/survey-creator-portal/.env.uat
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://uat-auth-service.example.com/api/auth

--- a/survey-creator-portal/README.md
+++ b/survey-creator-portal/README.md
@@ -10,3 +10,17 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Configuration
+
+The application uses Vite and `.env` files for environment-specific settings, primarily the API base URL (`VITE_API_BASE_URL`).
+
+### Running Locally
+- Run `npm run dev` (or `yarn dev`).
+- This uses `.env.local` (for `VITE_API_BASE_URL=http://127.0.0.1:8080/api/auth`) to connect to the local Spring Boot backend.
+- Ensure the backend (`auth-service`) is running, configured for the `local` profile.
+
+### Building for Environments
+- **Production:** `npm run build` (uses `.env.production`)
+- **UAT:** `npm run build:uat` (uses `.env.uat`)
+- `.env.development`, `.env.uat`, and `.env.production` contain placeholder API URLs that must be updated with actual backend URLs for those environments.

--- a/survey-creator-portal/package.json
+++ b/survey-creator-portal/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:uat": "vite build --mode uat",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest"

--- a/survey-creator-portal/src/contexts/AuthContext.jsx
+++ b/survey-creator-portal/src/contexts/AuthContext.jsx
@@ -6,7 +6,7 @@ export const AuthContext = createContext(); // Export AuthContext
 
 // Create an Axios instance
 const apiClient = axios.create({
-  baseURL: '/api/auth', // Assuming your Spring Boot app is served from the same domain
+  baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 
 export const AuthProvider = ({ children }) => {


### PR DESCRIPTION
This means I've set up environment-specific configurations for both the Spring Boot backend (auth-service) and the React frontend (survey-creator-portal).

For the Spring Boot backend (auth-service):
- I introduced Spring profiles: `local`, `dev`, `uat`, `prod`.
- I added `application-<profile>.properties` for each profile to manage CORS `allowed-origins`.
- I updated `pom.xml` to activate Spring profiles via Maven profiles (e.g., `mvn spring-boot:run -Plocal`).
- I added `WebConfig.java` to apply CORS settings programmatically based on the active profile.
- I created `auth-service/README.md` with instructions for you.

For the React frontend (survey-creator-portal):
- I added `.env` files for different environments: `.env.local`, `.env.development`, `.env.uat`, `.env.production`.
- I configured `VITE_API_BASE_URL` in these files to point to the respective backend URLs.
- I updated `AuthContext.jsx` to use `import.meta.env.VITE_API_BASE_URL`.
- I added a `build:uat` script to `package.json` for building the UAT environment (`vite build --mode uat`).
- I updated `survey-creator-portal/README.md` with environment configuration details for you.

This will allow you to deploy and run the application in different environments with distinct API endpoints and CORS settings.