### PR TITLE
feat: Add question table view to survey creator

### DIFF
--- a/survey-creator-portal/src/components/QuestionTableView.css
+++ b/survey-creator-portal/src/components/QuestionTableView.css
@@ -1,0 +1,31 @@
+/* Basic styles for QuestionTableView */
+table {
+  width: 100%;
+  border-collapse: collapse; /* Removes space between borders */
+  margin-top: 20px; /* Add some space above the table */
+  font-family: Arial, sans-serif; /* Consistent font */
+}
+
+th, td {
+  border: 1px solid #ddd; /* Light grey border for cells */
+  padding: 8px; /* Padding within cells */
+  text-align: left; /* Align text to the left */
+}
+
+th {
+  background-color: #f2f2f2; /* Light grey background for headers */
+  color: #333; /* Darker text for headers for contrast */
+}
+
+tr:nth-child(even) {
+  background-color: #f9f9f9; /* Zebra striping for rows */
+}
+
+tr:hover {
+  background-color: #e9e9e9; /* Highlight row on hover */
+}
+
+p {
+    margin-top: 10px;
+    font-style: italic;
+}

--- a/survey-creator-portal/src/components/QuestionTableView.jsx
+++ b/survey-creator-portal/src/components/QuestionTableView.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import './QuestionTableView.css';
+
+function QuestionTableView({ questions }) {
+  if (!questions || questions.length === 0) {
+    return <p>No questions to display.</p>;
+  }
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Question Title</th>
+          <th>Variable Name</th>
+          <th>Value Type</th>
+          <th>Options</th>
+        </tr>
+      </thead>
+      <tbody>
+        {questions.map((question) => (
+          <tr key={question.id}>
+            <td>{question.title}</td>
+            <td>{question.name || `question_${question.id}`}</td> {/* Assuming variable name might be 'name' or generated */}
+            <td>{question.answerType}</td>
+            <td>
+              {question.options && question.options.length > 0
+                ? question.options.map(option => option.text || option).join(', ')
+                : 'N/A'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default QuestionTableView;

--- a/survey-creator-portal/src/components/SurveyCreator.jsx
+++ b/survey-creator-portal/src/components/SurveyCreator.jsx
@@ -3,6 +3,7 @@ import './styles.css';
 import QuestionEditor from './QuestionEditor'; // Ensure this is imported
 import JsonViewModal from './JsonViewModal'; // Import JsonViewModal
 import PreviewModal from './PreviewModal'; // Import PreviewModal
+import QuestionTableView from './QuestionTableView'; // Import QuestionTableView
 import { saveSurveyToLocalStorage, loadSurveyFromLocalStorage } from '../utils/localStorage';
 
 function SurveyCreator() {
@@ -12,6 +13,7 @@ function SurveyCreator() {
   });
   const [isJsonModalOpen, setIsJsonModalOpen] = useState(false); // State for Json modal
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false); // State for Preview modal
+  const [isTableViewOpen, setIsTableViewOpen] = useState(false); // State for TableView
 
   useEffect(() => {
     saveSurveyToLocalStorage(questions);
@@ -41,6 +43,10 @@ function SurveyCreator() {
       <button onClick={addQuestion}>Add New Question</button>
       <button onClick={() => setIsJsonModalOpen(true)}>View JSON</button>
       <button onClick={() => setIsPreviewModalOpen(true)}>Preview Survey</button> {/* Button to open Preview modal */}
+      <button onClick={() => setIsTableViewOpen(!isTableViewOpen)}>
+        {isTableViewOpen ? 'Hide Table' : 'View Table'}
+      </button>
+      {isTableViewOpen && <QuestionTableView questions={questions} />}
       {questions.map((question, index) => (
         <QuestionEditor
           key={question.id}


### PR DESCRIPTION
This commit introduces a new table view for the survey creator. The table displays the following information for each question:
- Question Title
- Variable Name (derived from question.name or a generated ID)
- Value Type (answerType)
- Options (comma-separated list of option text or values)

A "View Table" / "Hide Table" button has been added to the SurveyCreator component to toggle the visibility of this new table. Basic styling has been applied to make the table readable.