### PR TITLE
Fix: Correct error message display on login failure

### DIFF
--- a/survey-creator-portal/src/contexts/AuthContext.jsx
+++ b/survey-creator-portal/src/contexts/AuthContext.jsx
@@ -117,7 +117,7 @@ export const AuthProvider = ({ children }) => {
       async (error) => {
         const originalRequest = error.config;
         // Prevent retry loops for login, token refresh endpoint itself, or if already retried
-        if (originalRequest.url === '/login' || originalRequest.url === '/refresh' || originalRequest._retry) {
+        if (originalRequest.url === '/auth/login' || originalRequest.url === '/auth/refresh' || originalRequest._retry) {
           return Promise.reject(error);
         }
 


### PR DESCRIPTION
Previously, if a login attempt failed with incorrect credentials (resulting in a 401 error from /auth/login), the API interceptor in AuthContext.jsx was incorrectly attempting to refresh a token. This was due to the interceptor's path checking not matching the actual API endpoint paths (e.g., checking for '/login' instead of '/auth/login').

If no refresh token was present (which is expected on a fresh, failed login), this led to a "No refresh token" error being displayed to you, masking the true "Invalid credentials" error.

This commit corrects the path checks in the Axios response interceptor within AuthContext.jsx to use '/auth/login' and '/auth/refresh'. This ensures that for failed login attempts, the interceptor correctly bypasses the token refresh logic, allowing the original error message from the backend to be displayed on the LoginScreen.