### PR TITLE
feat: Add survey question preview feature

### DIFF
--- a/survey-creator-portal/src/components/PreviewModal.jsx
+++ b/survey-creator-portal/src/components/PreviewModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import QuestionTableView from './QuestionTableView'; // Import QuestionTableView
 
 // Re-using modal styles (ideally, these would be in a shared CSS file)
 const modalStyle = {
@@ -21,50 +22,31 @@ const modalContentStyle = {
   maxHeight: '80vh',
   overflowY: 'auto',
   minWidth: '60%', // Adjusted for potentially more content
+  maxWidth: '90%', // Ensure modal is not too wide
 };
 
-function PreviewModal({ isOpen, onClose, questions }) {
+function PreviewModal({ isOpen, onClose, surveyJson }) { // Changed props
   if (!isOpen) {
     return null;
   }
 
+  // Extract questions from surveyJson
+  // SurveyJS stores questions in pages[0].elements
+  // Handle cases where surveyJson might be null or pages/elements are missing
+  const questions = surveyJson?.pages?.[0]?.elements || [];
+
   return (
     <div style={modalStyle} onClick={onClose}>
       <div style={modalContentStyle} onClick={(e) => e.stopPropagation()}>
-        <h2>Survey Preview</h2>
-        {questions.map((question, index) => (
-          <div key={question.id || index} style={{ marginBottom: '20px', borderBottom: '1px solid #eee', paddingBottom: '10px' }}>
-            <h3>{index + 1}. {question.title}</h3>
-            <p>{question.description}</p>
-            <div>
-              {question.answerType === 'text' && (
-                <input type="text" disabled placeholder="Your answer here" style={{ width: '80%', padding: '8px' }} />
-              )}
-              {question.answerType === 'textarea' && (
-                <textarea disabled placeholder="Your detailed answer here" style={{ width: '80%', padding: '8px', minHeight: '80px' }} />
-              )}
-              {(question.answerType === 'radio' || question.answerType === 'checkbox') && question.options && (
-                <div>
-                  {question.options.map((option, optIndex) => (
-                    <div key={optIndex} style={{ margin: '5px 0' }}>
-                      <input
-                        type={question.answerType}
-                        name={`question-${question.id}`} // Group radio buttons
-                        id={`q${question.id}-opt${optIndex}`}
-                        value={option}
-                        disabled
-                      />
-                      <label htmlFor={`q${question.id}-opt${optIndex}`} style={{ marginLeft: '8px' }}>
-                        {option}
-                      </label>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-        <button onClick={onClose} style={{ marginTop: '20px' }}>Close</button>
+        <h2>Survey Questions Preview</h2>
+        {questions.length > 0 ? (
+          <QuestionTableView questions={questions} />
+        ) : (
+          <p>This survey currently has no questions to display.</p>
+        )}
+        <button onClick={onClose} style={{ marginTop: '20px', padding: '10px 20px', cursor: 'pointer' }}>
+          Close
+        </button>
       </div>
     </div>
   );

--- a/survey-creator-portal/src/components/QuestionTableView.jsx
+++ b/survey-creator-portal/src/components/QuestionTableView.jsx
@@ -1,6 +1,42 @@
 import React from 'react';
 import './QuestionTableView.css';
 
+// Helper function to determine data type from SurveyJS question type
+function getDataType(surveyJsQuestionType, question) {
+  switch (surveyJsQuestionType) {
+    case 'text':
+    case 'comment':
+    case 'dropdown': // Single selection from a list
+    case 'radiogroup': // Single selection
+    case 'html': // Stores HTML content as a string
+      return 'string';
+    case 'checkbox': // Multiple selections
+    case 'tagbox': // Multiple selections, typically stored as an array of strings
+      return 'array';
+    case 'boolean':
+      return 'boolean';
+    case 'rating': // Typically numerical
+      return 'number';
+    case 'expression': // Result type can vary, often number or string. Defaulting to 'calculated'
+      return 'calculated';
+    case 'file':
+      return 'file'; // Or 'object' if storing metadata
+    case 'matrix': // Single choice per row, multiple rows. Often results in an object where keys are row values.
+    case 'matrixdropdown': // Multiple choices per row, multiple rows. Results in an object or array of objects.
+    case 'panel': // Represents a container, data is an object of its elements
+      return 'object';
+    case 'matrixdynamic': // Array of objects, as rows are dynamic
+    case 'paneldynamic': // Array of objects
+      return 'array of objects';
+    case 'imagepicker':
+      // Imagepicker can be single or multiple selection.
+      // Check question.multiSelect to determine if it's an array or string.
+      return question && question.multiSelect ? 'array' : 'string';
+    default:
+      return 'N/A'; // Default for unmapped types
+  }
+}
+
 function QuestionTableView({ questions }) {
   if (!questions || questions.length === 0) {
     return <p>No questions to display.</p>;
@@ -12,19 +48,21 @@ function QuestionTableView({ questions }) {
         <tr>
           <th>Question Title</th>
           <th>Variable Name</th>
-          <th>Value Type</th>
+          <th>Value Type (SurveyJS)</th>
+          <th>Data Type (Inferred)</th>
           <th>Options</th>
         </tr>
       </thead>
       <tbody>
         {questions.map((question) => (
-          <tr key={question.id}>
-            <td>{question.title}</td>
-            <td>{question.name || `question_${question.id}`}</td> {/* Assuming variable name might be 'name' or generated */}
-            <td>{question.answerType}</td>
+          <tr key={question.name || question.id}> {/* Use question.name as key if available, fallback to id */}
+            <td>{question.title || question.name}</td> {/* Display name if title is missing */}
+            <td>{question.name}</td>
+            <td>{question.type}</td> {/* This is the SurveyJS question type */}
+            <td>{getDataType(question.type, question)}</td> {/* Inferred data type */}
             <td>
-              {question.options && question.options.length > 0
-                ? question.options.map(option => option.text || option).join(', ')
+              {question.choices && question.choices.length > 0
+                ? question.choices.map(choice => choice.text || choice.value || choice).join(', ') // Handle choices from SurveyJS
                 : 'N/A'}
             </td>
           </tr>

--- a/survey-creator-portal/src/components/SurveyJsCreatorComponent.jsx
+++ b/survey-creator-portal/src/components/SurveyJsCreatorComponent.jsx
@@ -2,6 +2,8 @@ import React, { useContext, useEffect, useState } from 'react';
 import { SurveyCreatorModel  } from 'survey-creator-core';
 import { SurveyCreatorComponent, SurveyCreator } from 'survey-creator-react';
 import { AuthContext } from '../contexts/AuthContext';
+import PreviewModal from './PreviewModal';
+import QuestionTableView from './QuestionTableView';
 // components/SurveyCreator.tsx
 import "survey-core/survey-core.css";
 import "survey-creator-core/survey-creator-core.css";
@@ -38,6 +40,7 @@ function SurveyJsCreatorComponent({ json, options }) {
   const [status, setStatus] = useState('drafted');
   const [shareWithUsername, setShareWithUsername] = useState('');
   const [sharedUsersList, setSharedUsersList] = useState([]);
+  const [showPreviewModal, setShowPreviewModal] = useState(false);
   let [creator, setCreator] = useState();
 
   if (!creator) {
@@ -264,8 +267,16 @@ creator.saveSurveyFunc = (saveNo, callback) => {
   };
 
   return (<div>
-            <div style={{ padding: '10px', backgroundColor: '#f0f0f0', marginBottom: '10px' }}>
+            <div style={{ padding: '10px', backgroundColor: '#f0f0f0', marginBottom: '10px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <h3>Survey Settings</h3>
+                <div> {/* Container for buttons */}
+                    <button onClick={() => setShowPreviewModal(true)} style={{ marginRight: '10px' }}>
+                        Preview Survey
+                    </button>
+                    {/* Existing settings can be grouped or styled as needed */}
+                </div>
+            </div>
+            <div style={{ padding: '10px', backgroundColor: '#f0f0f0', marginBottom: '10px' }}>
                 <label htmlFor="surveyIdDisplay" style={{ marginRight: '10px' }}>Survey ID: </label>
                 <span id="surveyIdDisplay" style={{ marginRight: '20px', fontWeight:'bold' }}>{surveyId || 'New Survey'}</span>
                 <br/>
@@ -336,6 +347,13 @@ creator.saveSurveyFunc = (saveNo, callback) => {
     <div style={{ height: "100vh", width: "100%" }}>
       <SurveyCreatorComponent creator={creator} />
     </div>
+    {showPreviewModal && (
+        <PreviewModal
+            isOpen={showPreviewModal}
+            onClose={() => setShowPreviewModal(false)}
+            surveyJson={creator.JSON}
+        />
+    )}
     </div>
   );
 }


### PR DESCRIPTION
This commit introduces a feature that allows you to preview survey questions in a tabular format.

Key changes:

- Modified `SurveyJsCreatorComponent.jsx` to include a "Preview Survey" button and a modal to display the preview.
- Updated `PreviewModal.jsx` to receive survey JSON data and render the question table.
- Enhanced `QuestionTableView.jsx` to display question title, options, SurveyJS field type, and an inferred data type.
- The table now shows:
    - Question Title
    - Options (for applicable question types)
    - Value Type (SurveyJS specific type)
    - Data Type (Inferred, e.g., string, array, object)

This feature provides you with a quick overview of the survey structure and question details before publishing or sharing the survey.